### PR TITLE
Fix missing miner id

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -320,7 +320,8 @@ Miner.prototype = {
         return {
             blob: blob,
             job_id: newJob.id,
-            target: target
+            target: target,
+            id: this.id
         };
     },
     checkBan: function(validShare){


### PR DESCRIPTION
The miner id is missing in the new job, this is an issue when when there is one connection for several miners (like proxy).

Ref:
https://github.com/zone117x/node-cryptonote-pool/pull/256

Web miners using stratum proxy like this one: https://github.com/cazala/coin-hive-stratum
I noticed that the only pool that works fine is supportXMR, then I looked into the code and find that in yours code the miner id is missing when the pool send new job, so the proxy dont know to each miner notify this new job, so that miners continue to work on the old job, and then getting "Invalid job id" error.

Why is it works on supportXMR? because this line: https://github.com/Snipa22/nodejs-pool/blob/master/lib/pool.js#L499

I already tested your code with this change, it works great!